### PR TITLE
Enable network access in full-auto mode

### DIFF
--- a/.github/actions/codex/README.md
+++ b/.github/actions/codex/README.md
@@ -24,7 +24,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      # By default, Codex runs network disabled using --full-auto, so perform
+      # By default, Codex runs network enabled using --full-auto, so perform
       # any setup that requires network (such as installing dependencies)
       # before openai/codex-action.
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ files, and iterate - all under version control. In short, it's _chat-driven
 development_ that understands and executes your repo.
 
 - **Zero setup** - bring your OpenAI API key and it just works!
-- **Full auto-approval, while safe + secure** by running network-disabled and directory-sandboxed
+- **Full auto-approval, while safe + secure** by running commands in a directory-sandboxed environment with network access
 - **Multimodal** - pass in screenshots or diagrams to implement features ✨
 
 And it's **fully open-source** so you can see and contribute to how it develops!
@@ -169,9 +169,9 @@ Codex lets you decide _how much autonomy_ the agent receives and auto-approval p
 | ------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | **Suggest** <br>(default) | <li>Read any file in the repo                                                                       | <li>**All** file writes/patches<li> **Any** arbitrary shell commands (aside from reading files) |
 | **Auto Edit**             | <li>Read **and** apply-patch writes to files                                                        | <li>**All** shell commands                                                                      |
-| **Full Auto**             | <li>Read/write files <li> Execute shell commands (network disabled, writes limited to your workdir) | -                                                                                               |
+| **Full Auto**             | <li>Read/write files <li> Execute shell commands (network enabled, writes limited to your workdir) | -                                                                                               |
 
-In **Full Auto** every command is run **network-disabled** and confined to the
+In **Full Auto** every command is run **network-enabled** and confined to the
 current working directory (plus temporary files) for defense-in-depth. Codex
 will also show a warning/confirmation if you start in **auto-edit** or
 **full-auto** while the directory is _not_ tracked by Git, so you always have a
@@ -188,8 +188,7 @@ The hardening mechanism Codex uses depends on your OS:
 
   - Everything is placed in a read-only jail except for a small set of
     writable roots (`$PWD`, `$TMPDIR`, `~/.codex`, etc.).
-  - Outbound network is _fully blocked_ by default - even if a child process
-    tries to `curl` somewhere it will fail.
+  - Outbound network is allowed by default, so a child process can `curl` anywhere.
 
 - **Linux** - there is no sandboxing by default.
   We recommend using Docker for sandboxing, where Codex launches itself inside a **minimal

--- a/codex-cli/src/components/onboarding/onboarding-approval-mode.tsx
+++ b/codex-cli/src/components/onboarding/onboarding-approval-mode.tsx
@@ -25,7 +25,7 @@ export function OnboardingApprovalMode(): React.ReactElement {
           },
           {
             label:
-              "Auto-approve file reads, edits, and running commands network-disabled",
+              "Auto-approve file reads, edits, and running commands network enabled",
             value: AutoApprovalMode.FULL_AUTO,
           },
         ]}

--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -8,7 +8,7 @@ use codex_common::SandboxPermissionOption;
 
 #[derive(Debug, Parser)]
 pub struct SeatbeltCommand {
-    /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
+    /// Convenience alias for low-friction sandboxed automatic execution (network enabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 
@@ -25,7 +25,7 @@ pub struct SeatbeltCommand {
 
 #[derive(Debug, Parser)]
 pub struct LandlockCommand {
-    /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
+    /// Convenience alias for low-friction sandboxed automatic execution (network enabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -276,7 +276,7 @@ inherit = "none"
 set = { PATH = "/usr/bin", MY_FLAG = "1" }
 ```
 
-Currently, `CODEX_SANDBOX_NETWORK_DISABLED=1` is also added to the environment, assuming network is disabled. This is not configurable.
+Currently, `CODEX_SANDBOX_NETWORK_DISABLED` is no longer set, as network access remains enabled by default.
 
 ## notify
 

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -172,6 +172,7 @@ impl SandboxPolicy {
                 SandboxPermission::DiskFullReadAccess,
                 SandboxPermission::DiskWritePlatformUserTempFolder,
                 SandboxPermission::DiskWriteCwd,
+                SandboxPermission::NetworkFullAccess,
             ],
         }
     }

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -19,7 +19,7 @@ pub struct Cli {
     #[arg(long = "profile", short = 'p')]
     pub config_profile: Option<String>,
 
-    /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
+    /// Convenience alias for low-friction sandboxed automatic execution (network enabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -26,7 +26,7 @@ pub struct Cli {
     #[arg(long = "ask-for-approval", short = 'a')]
     pub approval_policy: Option<ApprovalModeCliArg>,
 
-    /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
+    /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network enabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 


### PR DESCRIPTION
## Summary
- allow network access in `new_full_auto_policy`
- update docs to reflect network-enabled full-auto mode
- tweak CLI help and onboarding text accordingly

## Testing
- `cargo test --workspace --locked` *(fails: Sandbox(LandlockRestrict))*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f352bd88330bae1fdf7c9ffd542